### PR TITLE
Optimization

### DIFF
--- a/Algorithms/02-Implementation/DivisibleSumPairs.cs
+++ b/Algorithms/02-Implementation/DivisibleSumPairs.cs
@@ -19,14 +19,11 @@ namespace _02_Implementation
             int[] a = Array.ConvertAll(a_temp, Int32.Parse);
 
             int results = 0;
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < n; i++)
             {
-                for (int j = i + 1; j < a.Length; j++)
+                for (int j = i + 1; j < n; j++)
                 {
-                    int firstValue = a[i];
-                    int secondValue = a[j];
-
-                    if ((firstValue + secondValue) % k == 0)
+                    if ((a[i] + a[j]) % k == 0)
                     {
                         results++;
                     }


### PR DESCRIPTION
1. Unnecessary array length property access, n was already given
2. Unnecessary stack pollution, new variables specified when there's only single array lookup